### PR TITLE
Met à jour suite au déménagement vers Framateam

### DIFF
--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -25,8 +25,6 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines), invitation à lire le message de topic du channel et tourner
   sept fois ses doigts dans ça bouche. On peut donc répondre sur [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines),
   mais la pénalité est d'avoir un clavier mouillé)
-* Sur [#haskell](https://framateam.org/artisan-e-s-du-logiciel/channels/haskell) on fait du Haskell les lundi midi (sauf quand on n'en fait pas)
-  et c'est chouette
 * Sur [#meugnon](https://framateam.org/artisan-e-s-du-logiciel/channels/meugnon) on poste parfois des photos de petits animaux trop meugnons awww rien
   que d'y penser je fonds
 * Sur [#accompagner](https://framateam.org/artisan-e-s-du-logiciel/channels/accompagner) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -12,31 +12,31 @@ Bienvenue parmi nous !
 
 ## Mode d'emploi
 
-Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTIONNEMENT.md) de cet espace Slack, et du [code de conduite](CODE_DE_CONDUITE.md) à respecter.
+Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTIONNEMENT.md) de cet espace Framateam, et du [code de conduite](CODE_DE_CONDUITE.md) à respecter.
 
 ## Petit guide des canaux
 
-* Sur [#annonces-de-service](https://artisans-du-logiciel.slack.com/messages/C04RH4P77/) on parle de slack
-* Sur [#discussions-générales](https://artisans-du-logiciel.slack.com/messages/CEWQVME0P) on parle d'artisanat logiciel
-* Sur [#random](https://artisans-du-logiciel.slack.com/messages/C04RH4P7K) on parle de tout et n'importe
+* Sur [#annonces-de-service](https://framateam.org/artisan-e-s-du-logiciel/channels/annonces-de-service) on parle de Framateam
+* Sur [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales) on parle d'artisanat logiciel
+* Sur [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random) on parle de tout et n'importe
   quoi (à moins que ce soit l'inverse, les deux channels échangent régulièrement leur rôle et ça n'a pas l'air de gêner plus que ça)
-* Sur [#joies](https://artisans-du-logiciel.slack.com/messages/C5N26RATU) on partage nos joies
-* Sur [#peines](https://artisans-du-logiciel.slack.com/messages/C59NG3E8P), nos peines (avant de répondre sur
-  [#peines](https://artisans-du-logiciel.slack.com/messages/C59NG3E8P), invitation à lire le message de topic du channel et tourner
-  sept fois ses doigts dans ça bouche. On peut donc répondre sur [#peines](https://artisans-du-logiciel.slack.com/messages/C59NG3E8P),
+* Sur [#joies](https://framateam.org/artisan-e-s-du-logiciel/channels/joies) on partage nos joies
+* Sur [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines), nos peines (avant de répondre sur
+  [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines), invitation à lire le message de topic du channel et tourner
+  sept fois ses doigts dans ça bouche. On peut donc répondre sur [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines),
   mais la pénalité est d'avoir un clavier mouillé)
-* Sur [#haskell](https://artisans-du-logiciel.slack.com/messages/C7KTJBB0C) on fait du Haskell les lundi midi (sauf quand on n'en fait pas)
+* Sur [#haskell](https://framateam.org/artisan-e-s-du-logiciel/channels/haskell) on fait du Haskell les lundi midi (sauf quand on n'en fait pas)
   et c'est chouette
-* Sur [#meugnon](https://artisans-du-logiciel.slack.com/messages/C58GGLY9Y) on poste parfois des photos de petits animaux trop meugnons awww rien
+* Sur [#meugnon](https://framateam.org/artisan-e-s-du-logiciel/channels/meugnon) on poste parfois des photos de petits animaux trop meugnons awww rien
   que d'y penser je fonds
-* Sur [#accompagner](https://artisans-du-logiciel.slack.com/messages/C04RXS0KX) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur
-  [#discussions-générales](https://artisans-du-logiciel.slack.com/messages/CEWQVME0P) ou [#random](https://artisans-du-logiciel.slack.com/messages/C04RH4P7K))
-* Sur [#business](https://artisans-du-logiciel.slack.com/messages/C04RY5J09) on partage parfois des opportunités de business
-* Sur [#dépôt-de-liens](https://artisans-du-logiciel.slack.com/messages/C7ZMVGPUM) on dépose parfois des liens intéressants à lire pour se muscler
-  le neurone (quand ça n'a pas lieu sur [#random](https://artisans-du-logiciel.slack.com/messages/C04RH4P7K) ou
-  [#discussions-générales](https://artisans-du-logiciel.slack.com/messages/CEWQVME0P))
-* Sur [#top50](https://artisans-du-logiciel.slack.com/messages/C7R2KV1UN) on partage parfois de la musique pour le plaisir des oreilles
+* Sur [#accompagner](https://framateam.org/artisan-e-s-du-logiciel/channels/accompagner) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur
+  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales) ou [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random))
+* Sur [#business](https://framateam.org/artisan-e-s-du-logiciel/channels/business) on partage parfois des opportunités de business
+* Sur [#dépôt-de-liens](https://framateam.org/artisan-e-s-du-logiciel/channels/depot-de-liens) on dépose parfois des liens intéressants à lire pour se muscler
+  le neurone (quand ça n'a pas lieu sur [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random) ou
+  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales))
+* Sur [#top50](https://framateam.org/artisan-e-s-du-logiciel/channels/top50) on partage parfois de la musique pour le plaisir des oreilles
   (quand... you get the idea)
-* [#pɹivilèges](https://artisans-du-logiciel.slack.com/messages/CBN6UN89L) a un statut particulier : les hommes cis blancs ne peuvent rien faire
+* [#pɹivilèges](https://framateam.org/artisan-e-s-du-logiciel/channels/privileges) a un statut particulier : les hommes cis blancs ne peuvent rien faire
   d'autre que lire et réagir avec une émoticône exprimant une émotion mais pas un avis
-* Sur [#télétravail](https://artisans-du-logiciel.slack.com/messages/CMJM92CDA), on parle de travail à la maison
+* Sur [#télétravail](https://framateam.org/artisan-e-s-du-logiciel/channels/teletravail), on parle de travail à la maison

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -17,7 +17,7 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
 ## Petit guide des canaux
 
 * Sur [#annonces-de-service](https://framateam.org/artisan-e-s-du-logiciel/channels/annonces-de-service) on parle de Framateam
-* Sur [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales) on parle d'artisanat logiciel
+* Sur [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square) on parle d'artisanat logiciel
 * Sur [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random) on parle de tout et n'importe
   quoi (à moins que ce soit l'inverse, les deux channels échangent régulièrement leur rôle et ça n'a pas l'air de gêner plus que ça)
 * Sur [#joies](https://framateam.org/artisan-e-s-du-logiciel/channels/joies) on partage nos joies
@@ -30,11 +30,11 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
 * Sur [#meugnon](https://framateam.org/artisan-e-s-du-logiciel/channels/meugnon) on poste parfois des photos de petits animaux trop meugnons awww rien
   que d'y penser je fonds
 * Sur [#accompagner](https://framateam.org/artisan-e-s-du-logiciel/channels/accompagner) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur
-  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales) ou [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random))
+  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square) ou [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random))
 * Sur [#business](https://framateam.org/artisan-e-s-du-logiciel/channels/business) on partage parfois des opportunités de business
 * Sur [#dépôt-de-liens](https://framateam.org/artisan-e-s-du-logiciel/channels/depot-de-liens) on dépose parfois des liens intéressants à lire pour se muscler
   le neurone (quand ça n'a pas lieu sur [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random) ou
-  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/discussions-generales))
+  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square))
 * Sur [#top50](https://framateam.org/artisan-e-s-du-logiciel/channels/top50) on partage parfois de la musique pour le plaisir des oreilles
   (quand... you get the idea)
 * [#pɹivilèges](https://framateam.org/artisan-e-s-du-logiciel/channels/privileges) a un statut particulier : les hommes cis blancs ne peuvent rien faire

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -31,6 +31,4 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square))
 * Sur [#top50](https://framateam.org/artisan-e-s-du-logiciel/channels/top50) on partage parfois de la musique pour le plaisir des oreilles
   (quand... you get the idea)
-* [#pɹivilèges](https://framateam.org/artisan-e-s-du-logiciel/channels/privileges) a un statut particulier : les hommes cis blancs ne peuvent rien faire
-  d'autre que lire et réagir avec une émoticône exprimant une émotion mais pas un avis
 * Sur [#télétravail](https://framateam.org/artisan-e-s-du-logiciel/channels/teletravail), on parle de travail à la maison

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -25,8 +25,6 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines), invitation à lire le message de topic du channel et tourner
   sept fois ses doigts dans ça bouche. On peut donc répondre sur [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines),
   mais la pénalité est d'avoir un clavier mouillé)
-* Sur [#accompagner](https://framateam.org/artisan-e-s-du-logiciel/channels/accompagner) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur
-  [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square) ou [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random))
 * Sur [#business](https://framateam.org/artisan-e-s-du-logiciel/channels/business) on partage parfois des opportunités de business
 * Sur [#dépôt-de-liens](https://framateam.org/artisan-e-s-du-logiciel/channels/depot-de-liens) on dépose parfois des liens intéressants à lire pour se muscler
   le neurone (quand ça n'a pas lieu sur [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random) ou

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -31,3 +31,5 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square))
 * Sur [#top50](https://framateam.org/artisan-e-s-du-logiciel/channels/top50) on partage parfois de la musique pour le plaisir des oreilles
   (quand... you get the idea)
+* Sur [#tech-jeux-de-code](https://framateam.org/artisan-e-s-du-logiciel/channels/tech-jeux-de-code) on fait des jeux de programmation
+  non-compétitifs pour progresser ensemble (comme Advent of Code)

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -31,4 +31,3 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square))
 * Sur [#top50](https://framateam.org/artisan-e-s-du-logiciel/channels/top50) on partage parfois de la musique pour le plaisir des oreilles
   (quand... you get the idea)
-* Sur [#télétravail](https://framateam.org/artisan-e-s-du-logiciel/channels/teletravail), on parle de travail à la maison

--- a/BIENVENUE.md
+++ b/BIENVENUE.md
@@ -25,8 +25,6 @@ Merci de prendre connaissance du petit [guide de fonctionnement](GUIDE_DE_FONCTI
   [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines), invitation à lire le message de topic du channel et tourner
   sept fois ses doigts dans ça bouche. On peut donc répondre sur [#peines](https://framateam.org/artisan-e-s-du-logiciel/channels/peines),
   mais la pénalité est d'avoir un clavier mouillé)
-* Sur [#meugnon](https://framateam.org/artisan-e-s-du-logiciel/channels/meugnon) on poste parfois des photos de petits animaux trop meugnons awww rien
-  que d'y penser je fonds
 * Sur [#accompagner](https://framateam.org/artisan-e-s-du-logiciel/channels/accompagner) on parle parfois d'accompagner des équipes (quand ça n'a pas lieu sur
   [#discussions-générales](https://framateam.org/artisan-e-s-du-logiciel/channels/town-square) ou [#random](https://framateam.org/artisan-e-s-du-logiciel/channels/random))
 * Sur [#business](https://framateam.org/artisan-e-s-du-logiciel/channels/business) on partage parfois des opportunités de business

--- a/CODE_DE_CONDUITE.md
+++ b/CODE_DE_CONDUITE.md
@@ -1,10 +1,10 @@
 # Code de conduite
 
-Tous les membres du Slack des Artisan·e·s du logiciel doivent s'engager à suivre le présent code de conduite. Les administrateurs sont les garants de sa bonne application, et la coopération de tous et toutes est souhaitée pour contribuer au bon fonctionnement de la communauté.
+Tous les membres du Framateam des Artisan·e·s du logiciel doivent s'engager à suivre le présent code de conduite. Les administrateurs sont les garants de sa bonne application, et la coopération de tous et toutes est souhaitée pour contribuer au bon fonctionnement de la communauté.
 
-Cet espace Slack est ouvert à toutes et tous, sans distinction d'âge, de niveau d'expérience, de situation professionnelle, de diplôme, d'origine, d'appartenance réelle ou supposée à une ethnie, à une nation, ou à une prétendue race, d'appartenance ou non à une religion déterminée, à une organisation politique ou syndicale, d'état de santé, de handicap, d'apparence physique, de genre, d'orientation ou d'identité sexuelle, de choix technologiques.
+Cet espace Framateam est ouvert à toutes et tous, sans distinction d'âge, de niveau d'expérience, de situation professionnelle, de diplôme, d'origine, d'appartenance réelle ou supposée à une ethnie, à une nation, ou à une prétendue race, d'appartenance ou non à une religion déterminée, à une organisation politique ou syndicale, d'état de santé, de handicap, d'apparence physique, de genre, d'orientation ou d'identité sexuelle, de choix technologiques.
 
-Il n'est pas approprié de poster des remarques ou des images à connotation sexuelle dans le contexte de cet espace Slack.
+Il n'est pas approprié de poster des remarques ou des images à connotation sexuelle dans le contexte de cet espace Framateam.
 
 Cet espace est semi-privé : les participant·e·s peuvent légitimement s'attendre à ce que leurs propos ne soient pas partagés en dehors. Si vous souhaitez republier tout ou partie d'une conversation, veillez à demander l'autorisation de tous les participant·e·s concerné·e·s.
 
@@ -12,6 +12,6 @@ Les aggressions ou le harcèlement à l'égard d'un·e participant·e ou d'un gr
 
 Toute personne à qui on demanderait de cesser un comportement de harcèlement est priée de le faire immédiatement.
 
-Devant un tel comportement, les administrateurs peuvent engager toute action qui leur semble appropriée, comme donner un avertissement ou exclure la personne concernée de l'espace Slack.
+Devant un tel comportement, les administrateurs peuvent engager toute action qui leur semble appropriée, comme donner un avertissement ou exclure la personne concernée de l'espace Framateam.
 
 Si vous êtes victime de harcèlement, ou que vous êtes témoin d'un tel comportement, ou pour tout autre problème, merci de contacter un administrateur dans les meilleurs délais.

--- a/GUIDE_DE_FONCTIONNEMENT.md
+++ b/GUIDE_DE_FONCTIONNEMENT.md
@@ -1,16 +1,16 @@
 # Guide de fonctionnement
 
-Ce document décrit le fonctionnement de l'espace Slack des Artisan·e·s du logiciel.
+Ce document décrit le fonctionnement de l'espace Framateam des Artisan·e·s du logiciel.
 
 ## Arrivée
 
 Si on a envie, on peut se présenter dans le canal #bienvenue.
 
-On peut aussi y poser toutes ses questions sur le fonctionnement de cet espace Slack.
+On peut aussi y poser toutes ses questions sur le fonctionnement de cet espace Framateam.
 
 ## Règles de participation
 
-Cet espace Slack est soumis à un [code de conduite](CODE_DE_CONDUITE.md), que chaque participant·e doit respecter.
+Cet espace Framateam est soumis à un [code de conduite](CODE_DE_CONDUITE.md), que chaque participant·e doit respecter.
 
 L'objectif de ces règles est de faire vivre un espace où l'on peut avoir des conversations de qualité et où chacune et chacun se sent libre de contribuer en toute sécurité.
 
@@ -22,7 +22,7 @@ Si vous avez des doutes ou des questions, n'hésitez pas à demander de l'aide !
 
 ## Trucs et astuces
 
-Slack permet de réagir avec des icônes :
+Framateam permet de réagir avec des icônes :
 
 - si vous n'êtes pas d'accord, vous pouvez l'exprimer simplement avec 👎 ; évitez par contre les icônes désobligeantes comme le caca ou le vomi
 
@@ -40,6 +40,6 @@ Une invitation est individuelle : ne l'adressez pas à un groupe, mais seulement
 
 ## Départ
 
-Si cet espace ne répond pas à vos besoins, vous êtes bien sûr libre de le quitter à tout moment : https://get.slack.help/hc/fr-fr/articles/203953146-Désactiver-votre-compte-Slack
+Si cet espace ne répond pas à vos besoins, vous êtes bien sûr libre de le quitter à tout moment en cliquant sur le menu de l'équipe puis "Quitter l'équipe".
 
 En cas de violation du [code de conduite](CODE_DE_CONDUITE.md), les administrateurs peuvent également décider d'exclure un·e membre.


### PR DESCRIPTION
Migration de la documentation suite au passage de Slack vers Framateam (instance Mattermost de Framasoft).

- Remplace toutes les références à "Slack" par "Framateam" dans les 3 fichiers de documentation
- Met à jour les URLs des canaux vers https://framateam.org/artisan-e-s-du-logiciel/channels/...
- Supprime les canaux qui n'existent plus (#haskell, #meugnon, #accompagner, #pɹivilèges, #télétravail)
- Ajoute le nouveau canal #tech-jeux-de-code
